### PR TITLE
Fix test execution

### DIFF
--- a/authservice.tests/pom.xml
+++ b/authservice.tests/pom.xml
@@ -88,14 +88,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <dependencies>
-                    <!-- Override the JUnit 5 provider from the parent POM's pluginManagement with a JUnit 4 provider that can run the pax exam tests -->
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit4</artifactId>
-                        <version>3.0.0-M3</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -418,17 +418,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>2.22.2</version>
                     <configuration>
                         <useSystemClassLoader>false</useSystemClassLoader>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.junit.jupiter</groupId>
-                            <artifactId>junit-jupiter-engine</artifactId>
-                            <version>${junit.jupiter.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.eluder.coveralls</groupId>


### PR DESCRIPTION
Version 2.22.2 of the maven-surefire plugin is now used to execute tests
which makes custom providers/dependencies unnecessary.